### PR TITLE
Fix duplicate stack trace at error.str field

### DIFF
--- a/errors.lua
+++ b/errors.lua
@@ -191,7 +191,11 @@ end
 -- @function tostring
 -- @treturn string
 function error_class.tostring(err)
-    return string.format('%s\n%s', err.str, err.stack or '')
+    local ret = err.str
+    if err.stack ~= nil then
+        ret = ret .. '\n' .. err.stack
+    end
+    return ret
 end
 
 --- Functions.

--- a/errors.lua
+++ b/errors.lua
@@ -91,11 +91,11 @@ function error_class:new(...)
 
     if self.capture_stack then
         stack = string.strip(debug.traceback("", level))
-        str = str .. '\n' .. stack
+        str = str
     end
 
     if self.log_on_creation then
-        log.error(str)
+        log.error(string.format("%s\n%s", str, stack))
     end
 
     local e = {
@@ -191,7 +191,7 @@ end
 -- @function tostring
 -- @treturn string
 function error_class.tostring(err)
-    return err.str
+    return string.format('%s\n%s', err.str, err.stack)
 end
 
 --- Functions.
@@ -296,7 +296,7 @@ local function wrap_with_suffix(suffix_format, ...)
                     stack_suffix = string.format(unpack(suffix_format))
                 end
 
-                obj.str = obj.str .. '\n' .. stack_suffix .. '\n' .. stack
+                obj.str = obj.str
                 obj.stack = obj.stack .. '\n' .. stack_suffix .. '\n' .. stack
             end
         end

--- a/errors.lua
+++ b/errors.lua
@@ -296,7 +296,6 @@ local function wrap_with_suffix(suffix_format, ...)
                     stack_suffix = string.format(unpack(suffix_format))
                 end
 
-                obj.str = obj.str
                 obj.stack = obj.stack .. '\n' .. stack_suffix .. '\n' .. stack
             end
         end

--- a/errors.lua
+++ b/errors.lua
@@ -91,11 +91,6 @@ function error_class:new(...)
 
     if self.capture_stack then
         stack = string.strip(debug.traceback("", level))
-        str = str
-    end
-
-    if self.log_on_creation then
-        log.error(string.format("%s\n%s", str, stack))
     end
 
     local e = {
@@ -107,6 +102,11 @@ function error_class:new(...)
         class_name = self.name
     }
     setmetatable(e, self.__instance_mt)
+
+    if self.log_on_creation then
+        log.error(e:tostring())
+    end
+
     return e
 end
 

--- a/errors.lua
+++ b/errors.lua
@@ -191,7 +191,7 @@ end
 -- @function tostring
 -- @treturn string
 function error_class.tostring(err)
-    return string.format('%s\n%s', err.str, err.stack)
+    return string.format('%s\n%s', err.str, err.stack or '')
 end
 
 --- Functions.

--- a/test/test_class.lua
+++ b/test/test_class.lua
@@ -15,7 +15,7 @@ local err = e_nostack:new()
 test:test('capture_stack = false', function(subtest)
     subtest:plan(2)
     subtest:is(err.stack, nil, 'check stack is nil')
-    subtest:is(err:tostring(), 'No-stack error: \n', "check tostring() doesn't contains stacktrace")
+    subtest:is(err:tostring(), 'No-stack error: ', "check tostring() doesn't contains stacktrace")
 end)
 -------------------------------------------------------------------------------
 

--- a/test/test_class.lua
+++ b/test/test_class.lua
@@ -12,8 +12,11 @@ test:plan(7)
 
 local e_nostack = errors.new_class('No-stack error', {capture_stack = false})
 local err = e_nostack:new()
-test:is(err.stack, nil, 'capture_stack = false')
-
+test:test('capture_stack = false', function(subtest)
+    subtest:plan(2)
+    subtest:is(err.stack, nil, 'check stack is nil')
+    subtest:is(err:tostring(), 'No-stack error: \n', "check tostring() doesn't contains stacktrace")
+end)
 -------------------------------------------------------------------------------
 
 local _log

--- a/test/test_errors.lua
+++ b/test/test_errors.lua
@@ -39,7 +39,7 @@ end
 _G.remote_4args_fn = remote_4args_fn
 
 local function check_error(test, got, expected)
-    test:plan(6)
+    test:plan(8)
 
     if not test:ok(got, 'have error') then
         test:diag('Got %s', got)
@@ -66,7 +66,10 @@ local function check_error(test, got, expected)
     end
 
     test:is(got.err, expected.err, 'err')
-    test:like(got.str, expected.str, 'str')
+    local err_str, err_stack = unpack(expected.str:split('\n', 1))
+    test:like(got.str, err_str, 'str')
+    test:like(got.stack, err_stack, 'stack')
+    test:like(got:tostring(), expected.str, 'newstyle tostring')
     test:is(got.str, tostring(got.str), 'tostring')
 end
 

--- a/test/test_errors.lua
+++ b/test/test_errors.lua
@@ -39,7 +39,7 @@ end
 _G.remote_4args_fn = remote_4args_fn
 
 local function check_error(test, got, expected)
-    test:plan(8)
+    test:plan(6)
 
     if not test:ok(got, 'have error') then
         test:diag('Got %s', got)
@@ -66,11 +66,8 @@ local function check_error(test, got, expected)
     end
 
     test:is(got.err, expected.err, 'err')
-    local err_str, err_stack = unpack(expected.str:split('\n', 1))
-    test:like(got.str, err_str, 'str')
-    test:like(got.stack, err_stack, 'stack')
-    test:like(got:tostring(), expected.str, 'newstyle tostring')
-    test:is(got.str, tostring(got.str), 'tostring')
+    test:like(tostring(got), expected.str, 'tostring()')
+    test:is(tostring(got), got:tostring(), ':tostring')
 end
 
 test:plan(39)


### PR DESCRIPTION
Now error.str field contains only error message and method error.tostring()
concatenates error message and stack trace.

Closes #7