### PR TITLE
Fix cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_custom_command(
   VERBATIM
 )
 
-if(LDOC_FOUND)
+if(Ldoc_FOUND)
   add_custom_target(doc ALL
     DEPENDS DOC_OUTPUT)
 else()

--- a/cmake/FindLdoc.cmake
+++ b/cmake/FindLdoc.cmake
@@ -5,7 +5,7 @@ find_program(LDOC ldoc
 )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LDOC
+find_package_handle_standard_args(Ldoc
     REQUIRED_VARS LDOC
 )
 


### PR DESCRIPTION
Fresh cmake versions (e.g. 3.19) issue a warning:

The package name passed to `find_package_handle_standard_args` (LDOC)
does not match the name of the calling package (Ldoc).  This can lead to
problems in calling code that expects `find_package` result variables
(e.g., `_FOUND`) to follow a certain pattern.

