### PR TITLE
build: bump cmake_minimum_required to 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed cmake_minimum_required to 3.5 
+
 ### Added
 
 - Add versioning support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Changed cmake_minimum_required to 3.5 
+- `CMake` minimum version bumped to 3.5.
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(errors NONE)
 


### PR DESCRIPTION
New cmake 4.0.0 removed compatibility with all version prior to 3.5

NO_DOC=build
NO_TEST=build

cmake Changelog: https://cmake.org/cmake/help/latest/release/4.0.html